### PR TITLE
Fix View3D View sidebar

### DIFF
--- a/Themes_Panel.py
+++ b/Themes_Panel.py
@@ -1,4 +1,3 @@
-
 import random
 import sys
 from mathutils import Matrix, Vector

--- a/Themes_Panel.py
+++ b/Themes_Panel.py
@@ -39,7 +39,7 @@ class THEMES_PT_Panel (bpy.types.Panel):
 # ------------------------------------------------------------------------------
 # THEMES PANEL 
 
-class VIEW3D_PT_view3d_properties(Panel):
+class VIEW3D_PT_AB_view3d_properties(Panel):
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'UI'
     bl_category = "Arc Blend"
@@ -216,7 +216,7 @@ class themes_panel_reset (bpy.types.Operator):
 
 def register():
     bpy.utils.register_class(THEMES_PT_Panel)
-    bpy.utils.register_class(VIEW3D_PT_view3d_properties)
+    bpy.utils.register_class(VIEW3D_PT_AB_view3d_properties)
     bpy.utils.register_class(themes_panel_mak)
     bpy.utils.register_class(themes_panel_white_chalk)
     bpy.utils.register_class(themes_panel_reset)
@@ -226,7 +226,7 @@ def register():
 
 def unregister():
     bpy.utils.unregister_class(THEMES_PT_Panel)
-    bpy.utils.unregister_class(VIEW3D_PT_view3d_properties)
+    bpy.utils.unregister_class(VIEW3D_PT_AB__view3d_properties)
     bpy.utils.unregister_class(themes_panel_mak)
     bpy.utils.unregister_class(themes_panel_white_chalk)
     bpy.utils.unregister_class(themes_panel_reset)


### PR DESCRIPTION
The file Themes_Panel.py redefines` VIEW3D_PT_view3d_properties`  which breaks the View tab in the 3D View Sidebar - I added an "AB" into the name to avoid the collision. Here's an example of the broken state:
![Captura de pantalla 2023-12-30 153239](https://github.com/stunmuffin/Arc_Blend/assets/4793742/9f8e1d8f-426b-4d8f-b035-bbcc831a12f0)

and here it is again after the fix:
![image](https://github.com/stunmuffin/Arc_Blend/assets/4793742/07ecfa4c-8d27-48fb-8c51-40beddc0b286)
 
Happy New Year!